### PR TITLE
Remove unnecessary 'np' reference in cell 3

### DIFF
--- a/Practice1.ipynb
+++ b/Practice1.ipynb
@@ -48,17 +48,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 14,
    "id": "b03912e9-a691-4f13-b1ff-bf3abb6353fa",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<module 'numpy' from 'C:\\\\Users\\\\Lenovo\\\\AppData\\\\Local\\\\Programs\\\\Python\\\\Python313\\\\Lib\\\\site-packages\\\\numpy\\\\__init__.py'>"
+       "np.float64(4.0)"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -66,8 +66,7 @@
    "source": [
     "import numpy as np\n",
     "a= np.array([4,4,6,7,4,1,5,6,4,3,5])\n",
-    "np.median(a)\n",
-    "np"
+    "np.median(a)"
    ]
   },
   {


### PR DESCRIPTION
- Removed an unused np reference in cell 3.
- The line served no purpose and was likely left in by mistake.
- No functional changes were made to the logic or output of the notebook.